### PR TITLE
Allow symphony 4.1.6 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
+        "symfony/framework-bundle": "^2.8|^3.0|^4.1",
         "contao/core-bundle": "^4.4",
         "heimrichhannot/contao-haste_plus": "~1.0"
     },


### PR DESCRIPTION
Solves backend crash in contao-privacy package installed in Contao 4.6